### PR TITLE
Fix for not retrieving all log events

### DIFF
--- a/logs/log.go
+++ b/logs/log.go
@@ -59,11 +59,13 @@ func (g *group) start(ch chan<- *Event) {
 
 // fetch logs relative to the given token and start time. We ignore when the log group is not found.
 func (g *group) fetch(nextToken *string, start int64, ch chan<- *Event) (*string, int64, error) {
+	limit := int64(10000)
 	res, err := g.Service.FilterLogEvents(&cloudwatchlogs.FilterLogEventsInput{
 		LogGroupName:  &g.name,
 		FilterPattern: &g.FilterPattern,
 		StartTime:     &start,
 		NextToken:     nextToken,
+		Limit:         &limit,
 	})
 
 	if e, ok := err.(awserr.Error); ok {

--- a/logs/log.go
+++ b/logs/log.go
@@ -78,7 +78,6 @@ func (g *group) fetch(nextToken *string, start int64, ch chan<- *Event) (*string
 	}
 
 	for _, event := range res.Events {
-		start = *event.Timestamp + 1
 		sec := *event.Timestamp / 1000
 		ch <- &Event{
 			Timestamp: time.Unix(sec, 0),


### PR DESCRIPTION
Sometimes, not all events will be retrieved from CloudWatch Logs. See this issue: https://github.com/apex/up/issues/733

This is because the code that updates the "start" of the time range based on observed timestamps is incorrect - it assumes the events come back in chronological order. CloudWatch Logs doesn't always return events in their chronological order. This is hinted at in the docs for the [interleaved](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html#CWL-FilterLogEvents-request-interleaved) parameter.

The proposed solution:
* stops updating the "start" time range - this alone will fix events not appearing
* keeps a fixed-size queue of recent event IDs, so duplicates can be ignored - this is important in "follow" mode because the last page is requested repeatedly

Please note, I don't write a lot of Go, so critique is welcome.

I tested this against 100 events, where this code would pull down ~31 events.

```go
package logs

import (
	"fmt"
	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/aws/session"
	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
	"testing"
	"time"
)

func TestLogs(t *testing.T) {
	tailer := New(Config{
		Service:       cloudwatchlogs.New(session.New(aws.NewConfig().WithRegion("us-west-1"))),
		FilterPattern: "{ $.message = \"test\" }",
		Follow:        true,
		GroupNames:    []string{"/aws/lambda/up-logs-issue"},
		StartTime:     time.Now().Add(-24 * time.Hour),
	})
	counter := 0
	for l := range tailer.Start() {
		counter += 1
		fmt.Print(counter, " ", l.Message)

	}
	fmt.Printf("Found %d messages\n", counter)
}
```
